### PR TITLE
Host specification

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Because the file leaves the Assemblyline infrastructure, if selected by the user
 |Name|Description|
 |:---:|:---|
 |api_key|Global VirusTotal API key for the system to use if the submitter doesn't provide their own|
+|host|VirusTotal host defaults to external `https://www.virustotal.com` but can be specified for testing or internal hosting.|
 |proxy|Proxy to connect to VirusTotal with|
 |av_config|Configuration block that tells the service to ignore/remap certain AV verdicts from the File Report. See [Service Manifest](./service_manifest.yml) for more details.|
 

--- a/service_manifest.yml
+++ b/service_manifest.yml
@@ -22,6 +22,7 @@ privileged: true
 
 config:
   api_key: ""
+  host: ""
   proxy: ""
   av_config:
     term_blocklist: ["Antiy-AVL", "APEX", "Jiangmin", "not-a-virus"] # Ignore results based on presence of term in signature combination

--- a/virustotal.py
+++ b/virustotal.py
@@ -54,7 +54,7 @@ class VirusTotal(ServiceBase):
         try:
             # Submitter's API key should be used first, global is a fallback if configured
             self.client = Client(apikey=request.get_param("api_key") or self.config.get("api_key"),
-                                 proxy=self.config.get('proxy') or None)
+                                 proxy=self.config.get('proxy') or None, host=self.config.get('host') or None)
         except ValueError as e:
             self.log.error("No API key found for VirusTotal")
             raise e


### PR DESCRIPTION
I have not tested this as I'm still working on building a dev environment, but hoping this is simple enough that you can just look it over (following the example of proxy).  Needed for an internal deployment.

Oddly, I don't see an option for `proxy` in https://virustotal.github.io/vt-py/_modules/vt/client.html#Client