### PR TITLE
handle key error in ip_domain

### DIFF
--- a/virustotal/reports/ip_domain.py
+++ b/virustotal/reports/ip_domain.py
@@ -23,11 +23,15 @@ def v3(doc: dict, av_processor: AVResultsProcessor) -> ResultSection:
     categories = list(set([v.lower() for v in attributes.get("categories", {}).values()]))
     body_dict = {
         "Categories": ", ".join(categories),
-        "Last Modification Date": format_time_from_epoch(attributes["last_modification_date"]),
         "Permalink": f"https://www.virustotal.com/gui/{doc['type']}/{doc['id']}",
     }
     if attributes.get("reputation"):
-        body_dict["Reputation"] = attributes["reputation"]
+        body_dict["Reputation"] = attributes.get("reputation")
+
+    if attributes.get("last_modification_date"):
+        body_dict["Last Modification Date"] = format_time_from_epoch(
+            attributes.get("last_modification_date")
+        )
 
     term = doc["id"]
     main_section = ResultSection(term)


### PR DESCRIPTION
PR handles this error that has been appearing in my environment in relation to v3
```
File "/var/lib/assemblyline/.local/lib/python3.11/site-packages/assemblyline_v4_service/common/base.py", line 180, in handle_task
    self.execute(request)
  File "/opt/al_service/virustotal/virustotal.py", line 231, in execute
    self.get_results(result_collection["ip"], "ip", "IPs", host_uri_map),
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/al_service/virustotal/virustotal.py", line 92, in get_results
    section = module.v3(report, self.processor)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/al_service/virustotal/reports/ip_domain.py", line 26, in v3
    "Last Modification Date": format_time_from_epoch(attributes["last_modification_date"]),
                                                     ~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^
KeyError: 'last_modification_date'
```

[Also updated to use .get() so it won't error out ](https://github.com/CybercentreCanada/assemblyline-service-virustotal/blob/7fa776ba1054b8f80b0b37c2ac4ae5b8f68d2c95/virustotal/reports/ip_domain.py#L30)

```
body_dict["Reputation"] = attributes.get("reputation")
```

